### PR TITLE
Fix volume percentage in per-channel oscilloscope

### DIFF
--- a/src/gui/chanOsc.cpp
+++ b/src/gui/chanOsc.cpp
@@ -887,9 +887,9 @@ void FurnaceGUI::drawChanOsc() {
                       case 'V': {
                         DivChannelState* chanState=e->getChanState(ch);
                         if (chanState==NULL) break;
-                        int volMax=chanState->volMax>>8;
+                        double volMax=chanState->volMax>>8;
                         if (volMax<1) volMax=1;
-                        text+=fmt::sprintf("%d%%",(chanState->volume>>8)/volMax);
+                        text+=fmt::sprintf("%.1f%%",((double)(chanState->volume>>8)/volMax)*100);
                         break;
                       }
                       case 'b': {


### PR DESCRIPTION
<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->

%V previously didn't use a number type supporting decimal numbers, which is required for this to correctly work. Also, you want it to say 100 instead of 1 so you have multiply it by 100.